### PR TITLE
spot/list のスタブ実装を追加

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -153,3 +153,6 @@ Thumbs.db
 
 # profiling data
 .prof
+
+# pycharm
+.idea/

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -1,7 +1,69 @@
 from django.http import HttpResponse
+import json
+
 
 def spot_list(request):
-    return HttpResponse("this is spot_list")
+    spots_json = spot_list_stub()
+    return HttpResponse(json.dumps(spots_json, indent=2))
+
 
 def search(request):
     return HttpResponse("this is search")
+
+
+def spot_list_stub():
+    spots = {
+        "attractions": [
+            {
+                "spot_id": 0,
+                "name": "ソアリン：ファンタスティック・フライト",
+                "lat": "35.62753096260775",
+                "lon": "139.88570175371126",
+                "play-time": 10,
+                "wait-time": 60,
+                "enable": True
+            },
+            {
+                "spot_id": 1,
+                "name": "ディズニーシー・トランジットスチーマーライン（メディテレーニアンハーバー）",
+                "lat": "35.626573169189264",
+                "lon": "139.88593456101927",
+                "play-time": 20,
+                "wait-time": -1,
+                "enable": False
+            }
+        ],
+        "restaurants": [
+            {
+                "spot_id": 29,
+                "name": "カフェ・ポルトフィーノ",
+                "lat": "35.62695264833476",
+                "lon": "139.88714679981504",
+                "enable": True
+            },
+            {
+                "spot_id": 31,
+                "name": "ザンビーニ･ブラザーズ･リストランテ",
+                "lat": "35.627169846655995",
+                "lon": "139.8860085445333",
+                "enable": False
+            }
+        ],
+        "shops": [
+            {
+                "spot_id": 67,
+                "name": "イル・ポスティーノ・ステーショナリー",
+                "lat": "35.627053829792416",
+                "lon": "139.8864666793604",
+                "enable": True,
+            },
+            {
+                "spot_id": 68,
+                "name": "ヴァレンティーナズ・スウィート",
+                "lat": "35.62689230914014",
+                "lon": "139.88835381094933",
+                "enable": False
+            }
+        ]
+    }
+    return spots


### PR DESCRIPTION
### 概要
* 要素は以下の通り
  * spot_id: スポットID(int)
  * name: スポット名称(string)
  * lat: 経度(float)
  * lon: 緯度(floag)
  * play-time: アトラクションの搭乗時間【m】(int)
  * wait-time: 待ち時間【m】 (int)
  * enable: やっているかどうか(bool)
* typeによっては存在しない要素もある
  * 例えば `restaurant` は `play-time` は存在しない

### 検証
http://localhost:8001/spot/list にアクセスして期待通りのjsonが返ってくることを確認
<img width="952" alt="8001" src="https://user-images.githubusercontent.com/33785163/116812007-58949800-ab87-11eb-8529-bc67a775af06.PNG">
