### PR TITLE
spot/list の静的データを取得する処理を実装

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 ENV PYTHONUNBUFFERED 1
-ENV PYTHONPATH="/code/algorithm/"
+ENV PYTHONPATH="/code/disneyapp/"
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/

--- a/backend/disneyapp/static_data_manager.py
+++ b/backend/disneyapp/static_data_manager.py
@@ -1,0 +1,43 @@
+import json
+
+
+class StaticDataManager:
+    __nodes = []
+    __links = []
+    __spots = []
+
+    @classmethod
+    def __load_nodes(cls):
+        with open("data/sea/nodes.json", "r", encoding="utf-8") as f:
+            json_data = json.load(f)
+            cls.__nodes = json_data["nodes"]
+
+    @classmethod
+    def __load_links(cls):
+        with open("data/sea/links.json", "r", encoding="utf-8") as f:
+            json_data = json.load(f)
+            cls.__links = json_data["links"]
+
+    @classmethod
+    def __load_spots(cls):
+        with open("data/sea/spots.json", "r", encoding="utf-8") as f:
+            json_data = json.load(f)
+            cls.__spots = json_data["spots"]
+
+    @classmethod
+    def get_nodes(cls):
+        if not cls.__nodes:
+            cls.__load_nodes()
+        return cls.__nodes
+
+    @classmethod
+    def get_links(cls):
+        if not cls.__links:
+            cls.__load_links()
+        return cls.__links
+
+    @classmethod
+    def get_spots(cls):
+        if not cls.__spots:
+            cls.__load_spots()
+        return cls.__spots

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from static_data_manager import StaticDataManager
 import json
+import copy
 
 
 def spot_list(request):
@@ -16,7 +17,8 @@ def search(request):
 
 def edit_static_spots_data(spots_json_org):
     spots_obj = {}
-    for spot_data in spots_json_org:
+    spots_json_org_copied = copy.deepcopy(spots_json_org)
+    for spot_data in spots_json_org_copied:
         target_type = spot_data["type"]
         del [spot_data["type"]]
         del [spot_data["nearest_node_id"]]

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -5,9 +5,10 @@ import copy
 
 
 def spot_list(request):
-    # spots_json = spot_list_stub()
     spots_json_org = StaticDataManager.get_spots()
-    return HttpResponse(json.dumps(edit_static_spots_data(spots_json_org), indent=2))
+    spots_json_edited = edit_static_spots_data(spots_json_org)
+    spots_json_with_dummy_dynamic_data = add_dummy_dynamic_data(spots_json_edited)
+    return HttpResponse(json.dumps(spots_json_with_dummy_dynamic_data, indent=2))
 
 
 def search(request):
@@ -22,6 +23,8 @@ def edit_static_spots_data(spots_json_org):
         target_type = spot_data["type"]
         del [spot_data["type"]]
         del [spot_data["nearest_node_id"]]
+        if spot_data.get("play-time"):
+            spot_data["play-time"] = int(spot_data["play-time"])
         if spots_obj.get(target_type):
             spots_obj[target_type].append(spot_data)
         else:
@@ -29,62 +32,15 @@ def edit_static_spots_data(spots_json_org):
     return spots_obj
 
 
-def spot_list_stub():
-    spots = {
-        "attractions": [
-            {
-                "spot_id": 0,
-                "name": "ソアリン：ファンタスティック・フライト",
-                "lat": "35.62753096260775",
-                "lon": "139.88570175371126",
-                "play-time": 10,
-                "wait-time": 60,
-                "enable": True
-            },
-            {
-                "spot_id": 1,
-                "name": "ディズニーシー・トランジットスチーマーライン（メディテレーニアンハーバー）",
-                "lat": "35.626573169189264",
-                "lon": "139.88593456101927",
-                "play-time": 20,
-                "wait-time": -1,
-                "enable": False
-            }
-        ],
-        "restaurants": [
-            {
-                "spot_id": 29,
-                "name": "カフェ・ポルトフィーノ",
-                "lat": "35.62695264833476",
-                "lon": "139.88714679981504",
-                "enable": True
-            },
-            {
-                "spot_id": 31,
-                "name": "ザンビーニ･ブラザーズ･リストランテ",
-                "lat": "35.627169846655995",
-                "lon": "139.8860085445333",
-                "enable": False
-            }
-        ],
-        "shops": [
-            {
-                "spot_id": 67,
-                "name": "イル・ポスティーノ・ステーショナリー",
-                "lat": "35.627053829792416",
-                "lon": "139.8864666793604",
-                "enable": True,
-            },
-            {
-                "spot_id": 68,
-                "name": "ヴァレンティーナズ・スウィート",
-                "lat": "35.62689230914014",
-                "lon": "139.88835381094933",
-                "enable": False
-            }
-        ]
-    }
-    return spots
+def add_dummy_dynamic_data(spots_json_edited):
+    spots_json_edited_copied = copy.deepcopy(spots_json_edited)
+    for key in spots_json_edited_copied.keys():
+        __spot_list = spots_json_edited_copied[key]
+        for spot in __spot_list:
+            if key == "attraction":
+                spot["wait-time"] = 60 # sec
+            spot["enable"] = True
+    return spots_json_edited_copied
 
 
 def search_stab():

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -1,15 +1,30 @@
 from django.http import HttpResponse
+from static_data_manager import StaticDataManager
 import json
 
 
 def spot_list(request):
-    spots_json = spot_list_stub()
-    return HttpResponse(json.dumps(spots_json, indent=2))
+    # spots_json = spot_list_stub()
+    spots_json_org = StaticDataManager.get_spots()
+    return HttpResponse(json.dumps(edit_static_spots_data(spots_json_org), indent=2))
 
 
 def search(request):
     route_json = search_stab()
     return HttpResponse(json.dumps(route_json, indent=2))
+
+
+def edit_static_spots_data(spots_json_org):
+    spots_obj = {}
+    for spot_data in spots_json_org:
+        target_type = spot_data["type"]
+        del [spot_data["type"]]
+        del [spot_data["nearest_node_id"]]
+        if spots_obj.get(target_type):
+            spots_obj[target_type].append(spot_data)
+        else:
+            spots_obj[target_type] = [spot_data]
+    return spots_obj
 
 
 def spot_list_stub():


### PR DESCRIPTION
### 概要
* `spot/list` で返却する情報のうち、静的データをstubではなく実データを使うように処理を実装
  * 動的データ（待ち時間、やっているかどうかなど）については一律ダミーデータを入れている

### 検証
`spot/list` で意図通りの形式のjsonが返却されることを確認
<img width="549" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/117230499-2f5e5b00-ae58-11eb-926c-d5b84e7de0dc.PNG">
